### PR TITLE
Make EnumValue compatible with Laravel 10

### DIFF
--- a/src/EnumValue.php
+++ b/src/EnumValue.php
@@ -17,7 +17,7 @@ trait EnumValue
           'enum_'.config('database.connections.' . (new static)->connection . '.prefix') . (new static)->getTable()
           , 60, function() {
             $fields = DB::connection((new static)->connection)->select(
-                DB::raw("SHOW COLUMNS FROM " . config('database.connections.' . (new static)->connection . '.prefix') . (new static)->getTable())
+                DB::raw("SHOW COLUMNS FROM " . config('database.connections.' . (new static)->connection . '.prefix') . (new static)->getTable())->getValue(DB::connection()->getQueryGrammar())
             );
             $result = [];
             foreach ($fields as $field) {


### PR DESCRIPTION
This PR makes laravel-db-enum compatible with Laravel 10
Change was made according to https://laravel.com/docs/10.x/upgrade#database-expressions